### PR TITLE
Change hash base for mulidd questions

### DIFF
--- a/text2qti/quiz.py
+++ b/text2qti/quiz.py
@@ -169,7 +169,10 @@ class Choice(object):
         # ID is based on hash of choice XML as well as question XML.  This
         # gives different IDs for identical choices in different questions.
         if is_shortans_fimb_multidd:
-            self.id = hashlib.blake2b(self.choice_xml.encode('utf8'), key=question_hash_digest).hexdigest()[:64]
+            # ID for short_ans_fimb_multidd is based on reference_word (unique per question) + choice XML as well as
+            # question XML because multiple drop downs with the same answers would have the same id otherwise
+            data = reference_word + self.choice_xml
+            self.id = hashlib.blake2b(data.encode('utf8'), key=question_hash_digest).hexdigest()[:64]
         else:
             self.id = hashlib.blake2b(self.choice_html_xml.encode('utf8'), key=question_hash_digest).hexdigest()[:64]
         self.md = md


### PR DESCRIPTION
Issue identified: answers for the multiple dropdown had the same id due to what the hash was based on.
Fix: Add a unique identifier per dropdown (reference_word) to the hash

`Known Issue #2: glitch with the multiple drop-down
When I uploaded it to Canvas even though the markdown only had a single answer, one of the questions had multiple answers selected which results in Canvas glitching.`
![image](https://user-images.githubusercontent.com/23159917/100571844-f3abdd80-3288-11eb-8f8e-54aab8ecbade.png)
[multiple_dropdown_test.txt](https://github.com/substance9/text2qti/files/5613956/multiple_dropdown_test.txt)
